### PR TITLE
🐛 카테고리 탭에 링크 컴포넌트 다시 적용

### DIFF
--- a/src/components/organizms/Header/index.tsx
+++ b/src/components/organizms/Header/index.tsx
@@ -47,20 +47,24 @@ const Header: React.FC<IHeaderProps> = ({ className = null }) => {
             </S.Logo>
           </Link>
           <ButtonList>
-            <S.StyledButton
-              key={CATEGORY_MOVIE}
-              active={contentType == "movie"}
-              onClick={onMovieClick}
-            >
-              {CATEGORY_MOVIE}
-            </S.StyledButton>
-            <S.StyledButton
-              key={CATEGORY_TV}
-              active={contentType == "tv"}
-              onClick={onTVClick}
-            >
-              {CATEGORY_TV}
-            </S.StyledButton>
+            <Link to="/">
+              <S.StyledButton
+                key={CATEGORY_MOVIE}
+                active={contentType == "movie"}
+                onClick={onMovieClick}
+              >
+                {CATEGORY_MOVIE}
+              </S.StyledButton>
+            </Link>
+            <Link to="/">
+              <S.StyledButton
+                key={CATEGORY_TV}
+                active={contentType == "tv"}
+                onClick={onTVClick}
+              >
+                {CATEGORY_TV}
+              </S.StyledButton>
+            </Link>
           </ButtonList>
         </S.LeftSideContainer>
         <S.RightSideContainer>


### PR DESCRIPTION
- 최적화하면서 생긴 오류 수정